### PR TITLE
mod.conf -- no need to rename dir

### DIFF
--- a/mod.conf
+++ b/mod.conf
@@ -1,0 +1,1 @@
+name = biofuel


### PR DESCRIPTION
Adding this one file keeps the user from having to rename folders