### PR TITLE
Fix hopper compatibility

### DIFF
--- a/refinery.lua
+++ b/refinery.lua
@@ -13,14 +13,16 @@
 local S = minetest.get_translator("biofuel")
 
 -- hopper compat
-hopper:add_container({
-	{"top", "biofuel:refinery", "dst"},
-	{"bottom", "biofuel:refinery", "src"},
-	{"side", "biofuel:refinery", "src"},
-	{"top", "biofuel:refinery_active", "dst"},
-	{"bottom", "biofuel:refinery_active", "src"},
-	{"side", "biofuel:refinery_active", "src"},
-})
+if minetest.get_modpath("hopper") then
+	hopper:add_container({
+		{"top", "biofuel:refinery", "dst"},
+		{"bottom", "biofuel:refinery", "src"},
+		{"side", "biofuel:refinery", "src"},
+		{"top", "biofuel:refinery_active", "dst"},
+		{"bottom", "biofuel:refinery_active", "src"},
+		{"side", "biofuel:refinery_active", "src"},
+	})
+end
 
 
 -- pipeworks compat


### PR DESCRIPTION
```
2020-12-28 07:11:41: ERROR[Main]: ModError: Failed to load and run script from /var/lib/minetest/.minetest/worlds/world/worldmods/biofuel/init.lua:
2020-12-28 07:11:41: ERROR[Main]: ...minetest/worlds/world/worldmods/biofuel/refinery.lua:16: attempt to index global 'hopper' (a nil value)
2020-12-28 07:11:41: ERROR[Main]: stack traceback:
2020-12-28 07:11:41: ERROR[Main]: 	...minetest/worlds/world/worldmods/biofuel/refinery.lua:16: in main chunk
2020-12-28 07:11:41: ERROR[Main]: 	[C]: in function 'dofile'
2020-12-28 07:11:41: ERROR[Main]: 	...st/.minetest/worlds/world/worldmods/biofuel/init.lua:2: in main chunk
```