### PR TITLE
add support for 3 more plantlife nodes

### DIFF
--- a/refinery.lua
+++ b/refinery.lua
@@ -57,8 +57,9 @@ biomass.convertible_nodes = {
 							'cucina_vegana:flax', 'cucina_vegana:flax_roasted', 'cucina_vegana:sunflower',					-- cucina_vegana
 							'cucina_vegana:soy', 'cucina_vegana:chives', 
 							'vines:vines', 'vines:rope', 'vines:rope_block',												-- Vines
-							'trunks:twig_1', 'bushes:BushLeaves1', 'bushes:BushLeaves2', 
-							'dryplants:grass', 'dryplants:hay', 'dryplants:reed', 'dryplants:wetreed',
+							'trunks:moss_plain_0', 'trunks:moss_with_fungus_0', 'trunks:twig_1',
+							'bushes:BushLeaves1', 'bushes:BushLeaves2',
+							'dryplants:grass', 'dryplants:hay', 'dryplants:reed', 'dryplants:reedmace_sapling', 'dryplants:wetreed',
 							'poisonivy:climbing', 'poisonivy:seedling', 'poisonivy:sproutling',
 							}
 


### PR DESCRIPTION
This PR adds support for 3 more plantlife nodes:
- `trunks:moss_plain_0` https://github.com/mt-mods/plantlife_modpack/blob/7094d8a369d9d10d7a4828f74fec13c4d9ae452c/trunks/nodes.lua#L101
- `trunks:moss_with_fungus_0` https://github.com/mt-mods/plantlife_modpack/blob/7094d8a369d9d10d7a4828f74fec13c4d9ae452c/trunks/nodes.lua#L121
- `dryplants:reedmace_sapling` https://github.com/mt-mods/plantlife_modpack/blob/7094d8a369d9d10d7a4828f74fec13c4d9ae452c/dryplants/reedmace.lua#L257
